### PR TITLE
adjust the clang version order to change the build order 

### DIFF
--- a/.github/workflows/build-amd64.yml
+++ b/.github/workflows/build-amd64.yml
@@ -15,38 +15,38 @@ jobs:
   build:
     strategy:
       matrix:
-        clang-version: [ 7, 8, 9, 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18 ]
+        clang-version: [ 18, 17, 16, 15, 14, 13, 12.0.1, 12, 11, 10, 9, 8, 7 ]
         os: [ linux, macosx, windows ]
         include:
-          - clang-version: 7
-            release: llvm-project-7.1.0
-          - clang-version: 8
-            release: llvm-project-8.0.1
-            extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF'
-          - clang-version: 9
-            release: llvm-project-9.0.1
-            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+          - clang-version: 18
+            release: llvm-project-18.1.5.src
+          - clang-version: 17
+            release: llvm-project-17.0.4.src
+          - clang-version: 16
+            release: llvm-project-16.0.3.src
+          - clang-version: 15
+            release: llvm-project-15.0.2.src
+          - clang-version: 14
+            release: llvm-project-14.0.0.src
+          - clang-version: 13
+            release: llvm-project-13.0.0.src
+          - clang-version: 12.0.1
+            release: llvm-project-12.0.1.src
+          - clang-version: 12
+            release: llvm-project-12.0.0.src
+          - clang-version: 11
+            release: llvm-project-11.1.0.src
           - clang-version: 10
             release: llvm-project-10.0.1
             extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
-          - clang-version: 11
-            release: llvm-project-11.1.0.src
-          - clang-version: 12
-            release: llvm-project-12.0.0.src
-          - clang-version: 12.0.1
-            release: llvm-project-12.0.1.src
-          - clang-version: 13
-            release: llvm-project-13.0.0.src
-          - clang-version: 14
-            release: llvm-project-14.0.0.src
-          - clang-version: 15
-            release: llvm-project-15.0.2.src
-          - clang-version: 16
-            release: llvm-project-16.0.3.src
-          - clang-version: 17
-            release: llvm-project-17.0.4.src
-          - clang-version: 18
-            release: llvm-project-18.1.0.src
+          - clang-version: 9
+            release: llvm-project-9.0.1
+            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+          - clang-version: 8
+            release: llvm-project-8.0.1
+            extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF'
+          - clang-version: 7
+            release: llvm-project-7.1.0
           - os: linux
             runner: ubuntu-22.04
             os-cmake-args: '-DLLVM_BUILD_STATIC=ON -DCMAKE_CXX_FLAGS="-s -flto" ${POSIX_CMAKE_ARGS}'


### PR DESCRIPTION
GitHub Aciton build always failed recently https://github.com/cpp-linter/clang-tools-static-binaries/actions/runs/9009739681/job/24754531130

I tried to change the Clang version in order to build a higher version of Clang first.