### PR TITLE
fix: dyld[1952]: Library not loaded: @rpath/libLLVM.dylib

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,7 @@ jobs:
         -DLLVM_ENABLE_ASSERTIONS=OFF
         -DLLVM_LINK_LLVM_DYLIB=ON
         -DLLVM_BUILD_LLVM_DYLIB=ON
+        -DCLANG_LINK_CLANG_DYLIB=ON
       LINUX_CMAKE_ARGS: '-DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_C_COMPILER=gcc-10'
       RELEASE: '${{ matrix.release }}'
       suffix: '${{ matrix.clang-version }}_${{ matrix.os }}-amd64'


### PR DESCRIPTION
Try to fix failures of https://github.com/cpp-linter/clang-tools-pip/actions/runs/14260455980

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved the macOS build process to enhance dynamic linking support for better build stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->