### PR TITLE
fix: set MACOS_CMAKE_ARGS for diff clang versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,19 +80,14 @@ jobs:
     runs-on: ${{ matrix.runner }}
     if: ${{ github.actor != 'dependabot[bot]' }}
     env:
-      COMMON_CMAKE_ARGS: >
-        -DBUILD_SHARED_LIBS=OFF
-        -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra"
+      COMMON_CMAKE_ARGS: '-DBUILD_SHARED_LIBS=OFF -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra"'
       MACOS_CMAKE_ARGS: >
         -DCMAKE_BUILD_TYPE=MinSizeRel
         -DCMAKE_CXX_COMPILER=g++-11
         -DCMAKE_C_COMPILER=gcc-11
         -DZSTD_STATIC_LINKING_ONLY=1
         -DLLVM_ENABLE_ASSERTIONS=OFF
-      LINUX_CMAKE_ARGS: > 
-        -DCMAKE_BUILD_TYPE=MinSizeRel
-        -DCMAKE_CXX_COMPILER=g++-10
-        -DCMAKE_C_COMPILER=gcc-10
+      LINUX_CMAKE_ARGS: '-DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_C_COMPILER=gcc-10'
       RELEASE: '${{ matrix.release }}'
       suffix: '${{ matrix.clang-version }}_${{ matrix.os }}-amd64'
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,14 +80,19 @@ jobs:
     runs-on: ${{ matrix.runner }}
     if: ${{ github.actor != 'dependabot[bot]' }}
     env:
-      COMMON_CMAKE_ARGS: '-DBUILD_SHARED_LIBS=OFF -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra"'
+      COMMON_CMAKE_ARGS: >
+        -DBUILD_SHARED_LIBS=OFF
+        -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra"
       MACOS_CMAKE_ARGS: >
         -DCMAKE_BUILD_TYPE=MinSizeRel
         -DCMAKE_CXX_COMPILER=g++-11
         -DCMAKE_C_COMPILER=gcc-11
         -DZSTD_STATIC_LINKING_ONLY=1
         -DLLVM_ENABLE_ASSERTIONS=OFF
-      LINUX_CMAKE_ARGS: '-DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_C_COMPILER=gcc-10'
+      LINUX_CMAKE_ARGS: > 
+        -DCMAKE_BUILD_TYPE=MinSizeRel
+        -DCMAKE_CXX_COMPILER=g++-10
+        -DCMAKE_C_COMPILER=gcc-10
       RELEASE: '${{ matrix.release }}'
       suffix: '${{ matrix.clang-version }}_${{ matrix.os }}-amd64'
     steps:
@@ -149,6 +154,9 @@ jobs:
         brew update
         brew upgrade
         brew cleanup
+        echo "Append DYLIB options..."
+        MACOS_CMAKE_ARGS="$MACOS_CMAKE_ARGS -DLLVM_LINK_LLVM_DYLIB=ON -DLLVM_BUILD_LLVM_DYLIB=ON -DCLANG_LINK_CLANG_DYLIB=ON"
+        echo "MACOS_CMAKE_ARGS=$MACOS_CMAKE_ARGS" >> $GITHUB_ENV
     - name: CMake
       run: cmake -S ${{ matrix.release }}/llvm -B ${{ matrix.release }}/build ${{ env.COMMON_CMAKE_ARGS }} ${{ matrix.os-cmake-args }} ${{ matrix.extra-cmake-args }}
     - name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+venv
+.venv


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced build and environment settings for improved macOS compatibility.
  - Introduced a new `.gitignore` file to prevent tracking of local virtual environment directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->