### PR TITLE
fix: add `-DZLIB_USE_STATIC_LIBS=ON` to `MACOS_CMAKE_ARGS`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,7 +185,7 @@ jobs:
         cat clang-tidy-${{ env.suffix }}.sha512sum
         cat clang-apply-replacements-${{ env.suffix }}.sha512sum
     - name: Upload artifacts
-      if: ${{ github.actor != 'dependabot[bot]' }} || github.event_name != 'pull_request'
+      if: github.event_name != 'pull_request'
       uses: actions/upload-artifact@v4
       with:
         name: clang-tools-${{ matrix.release }}-${{ env.suffix }}
@@ -193,7 +193,7 @@ jobs:
         retention-days: 1
   draft-release:
     runs-on: ubuntu-22.04
-    if: ${{ github.actor != 'dependabot[bot]' }} || github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request'
     needs: build
     steps:
       - name: Download artifacts


### PR DESCRIPTION
Try to fix the following error on macOS for Clang 19 and 20 

```bash
dyld[66544]: dyld cache '(null)' not loaded: syscall to map cache into shared region failed
dyld[66544]: Library not loaded: /usr/lib/libz.1.dylib
  Referenced from: <EEA7FA6A-794A-3BF4-828D-F0805E9747ED> /Users/runner/work/clang-tools-static-binaries/clang-tools-static-binaries/llvm-project-20.1.0.src/build/bin/clang-tidy-20_macosx-amd64
  Reason: tried: '/usr/lib/libz.1.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/usr/lib/libz.1.dylib' (no such file), '/usr/lib/libz.1.dylib' (no such file, no dyld cache), '/usr/local/lib/libz.1.dylib' (no such file)
/Users/runner/work/_temp/e411c983-0e12-4c88-954f-04958f46d8db.sh: line 9: 66544 Abort trap: 6           ./clang-tidy-20_macosx-amd64 --version
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved macOS build process to ensure required libraries are available for Clang version 18 and above.
  - Updated build configuration to use static linking for zlib libraries on macOS.
  - Added verification step to confirm the file type of the clang-tidy binary on macOS.
  - Allowed build workflow to continue even if clang-tidy version checks fail on macOS.
  - Simplified artifact upload and release step conditions to streamline workflow execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->