### PR TITLE
docs: update readme about clang-tidy

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The supported versions are as follows:
 |             |macOS 64   |✔️|✔️|✔️ |✔️|✔️|✔️ |✔️|✔️ |✔️ |✔️|✔️| ✔️|✔️|
 
 > [!NOTE]
-> clang-tidy v19+ failed to run on MacOS (see [issue #51](https://github.com/cpp-linter/clang-tools-static-binaries/issues/51))
+> clang-tidy v19+ failed to run on macOS (see [issue #51](https://github.com/cpp-linter/clang-tools-static-binaries/issues/51))
 >
 > Remove Support v7 (released in May 2019) by February 2025.
 


### PR DESCRIPTION
fixup of #50 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the support table to mark clang-tidy versions 19 and 20 as unsupported on macOS 64-bit.
  - Added a note explaining that clang-tidy versions 19 and above fail to run on macOS, with a reference to a related GitHub issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->