### PR TITLE
update build pipeline to fix macos build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,14 +56,14 @@ jobs:
             extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF'
           - os: linux
             runner: ubuntu-22.04
-            os-cmake-args: '-DLLVM_BUILD_STATIC=ON -DCMAKE_CXX_FLAGS="-s -flto" ${LINUX_CMAKE_ARGS}'
+            os-cmake-args: '-DLLVM_BUILD_STATIC=ON -DCMAKE_CXX_FLAGS="-s -flto" ${POSIX_CMAKE_ARGS} ${LINUX_CMAKE_ARGS}'
             build-args: '-j$(nproc)'
             bindir: '/build/bin'
             dotexe: ''
             shacmd: 'sha512sum'
           - os: macosx
-            runner: macos-13 # macos intel
-            os-cmake-args: '-DCMAKE_CXX_FLAGS="-static-libgcc -static-libstdc++ -flto -ffunction-sections -fdata-sections" -DCMAKE_OSX_DEPLOYMENT_TARGET=11 ${MACOS_CMAKE_ARGS}'
+            runner: macos-13
+            os-cmake-args: '-DCMAKE_CXX_FLAGS="-static-libgcc -static-libstdc++ -flto" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 ${POSIX_CMAKE_ARGS} ${MACOS_CMAKE_ARGS}'
             build-args: '-j$(sysctl -n hw.ncpu)'
             bindir: '/build/bin'
             dotexe: ''
@@ -78,18 +78,11 @@ jobs:
             extra-tar-args: '--exclude=${RELEASE}/clang/test/Driver/Inputs/* --exclude=${RELEASE}/libcxx/test/std/input.output/filesystems/Inputs/static_test_env/* --exclude=${RELEASE}/libclc/amdgcn-mesa3d'
             extra-tar-args-cfe: '--exclude=cfe-${version}.src/test/Driver/Inputs/*'
     runs-on: ${{ matrix.runner }}
-    if: ${{ github.actor != 'dependabot[bot]' }}
     env:
       COMMON_CMAKE_ARGS: '-DBUILD_SHARED_LIBS=OFF -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra"'
-      MACOS_CMAKE_ARGS: >
-        -DCMAKE_BUILD_TYPE=MinSizeRel
-        -DCMAKE_CXX_COMPILER=g++-14
-        -DCMAKE_C_COMPILER=gcc-14
-        -DZSTD_STATIC_LINKING_ONLY=1
-        -DLLVM_ENABLE_ASSERTIONS=OFF
-        -DZLIB_USE_STATIC_LIBS=ON
-        -DLLVM_TARGETS_TO_BUILD=X86
-      LINUX_CMAKE_ARGS: '-DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_C_COMPILER=gcc-10'
+      LINUX_CMAKE_ARGS: '-DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_C_COMPILER=gcc-10'
+      MACOS_CMAKE_ARGS: '-DCMAKE_CXX_COMPILER=g++-14 -DCMAKE_C_COMPILER=gcc-14'
+      POSIX_CMAKE_ARGS: '-DCMAKE_BUILD_TYPE=MinSizeRel'
       RELEASE: '${{ matrix.release }}'
       suffix: '${{ matrix.clang-version }}_${{ matrix.os }}-amd64'
     steps:
@@ -141,34 +134,37 @@ jobs:
     - name: Patch cmake implicit link libraries on macOS
       if: ${{ matrix.os == 'macosx' }}
       shell: bash
-      run: |
-        BREW_PREFIX=$(brew --prefix)
-        FILES=$(find "$BREW_PREFIX" -name CMakeParseImplicitLinkInfo.cmake)
-        for file in $FILES; do
-          echo "Patching $file"
-          sed -i.backup 's/gcc_eh.*|/gcc_eh.*|gcc_ext.*|/g' "$file"
-        done
-    - name: CMake
+      run: sed -i.backup 's/gcc_eh.\*|/gcc_eh.*|gcc_ext.*|/g' $(find /usr/local/Cellar -name CMakeParseImplicitLinkInfo.cmake)
+    - name: Cmake
       run: cmake -S ${{ matrix.release }}/llvm -B ${{ matrix.release }}/build ${{ env.COMMON_CMAKE_ARGS }} ${{ matrix.os-cmake-args }} ${{ matrix.extra-cmake-args }}
     - name: Build
       run: cmake --build ${{ matrix.release }}/build ${{ matrix.build-args }} --target clang-format clang-query clang-tidy clang-apply-replacements
     - name: Print dependencies
       if: ${{ matrix.os == 'macosx' }}
       run: otool -L ${{ matrix.release }}/build/bin/clang-format
-    - name: Rename output binary and test
+    - name: Smoke test clang-tools (macos, linux)
+      if: ${{ matrix.os == 'macosx' || matrix.os == 'linux' }}
+      run: |
+        cd ${{ matrix.release }}/build/bin
+        ./clang-format --version
+        ./clang-query --version
+        ./clang-tidy --version
+        ./clang-apply-replacements --version
+    - name: Smoke test clang-tools (windows)
+      if: ${{ matrix.os == 'windows' }}
+      run: |
+        cd ${{ matrix.release }}${{ matrix.bindir }}
+        clang-format${{ matrix.dotexe }} --version
+        clang-query${{ matrix.dotexe }} --version
+        clang-tidy${{ matrix.dotexe }} --version
+        clang-apply-replacements${{ matrix.dotexe }} --version
+    - name: Rename output binary
       run: |
         cd ${{ matrix.release }}${{ matrix.bindir }}
         mv clang-format${{ matrix.dotexe }} clang-format-${{ env.suffix }}${{ matrix.dotexe }}
         mv clang-query${{ matrix.dotexe }} clang-query-${{ env.suffix }}${{ matrix.dotexe }}
         mv clang-tidy${{ matrix.dotexe }} clang-tidy-${{ env.suffix }}${{ matrix.dotexe }}
         mv clang-apply-replacements${{ matrix.dotexe }} clang-apply-replacements-${{ env.suffix }}${{ matrix.dotexe }}
-
-        ./clang-format-${{ env.suffix }}${{ matrix.dotexe }} --version
-        ./clang-query-${{ env.suffix }}${{ matrix.dotexe }} --version
-        file ./clang-tidy-${{ env.suffix }}${{ matrix.dotexe }}
-        ./clang-tidy-${{ env.suffix }}${{ matrix.dotexe }} --version
-        ./clang-apply-replacements-${{ env.suffix }}${{ matrix.dotexe }} --version
-      continue-on-error: true # continue to publish when clang-tidy 18+ failed on MacOS
     - name: Create and print sha512sum
       shell: bash
       run: |
@@ -188,6 +184,76 @@ jobs:
         name: clang-tools-${{ matrix.release }}-${{ env.suffix }}
         path: "${{ matrix.release }}${{ matrix.bindir }}/clang-*-${{ env.suffix }}*"
         retention-days: 1
+  test-release:
+    strategy:
+      matrix:
+        os: [ linux, macosx, windows ]
+        include:
+          - os: linux
+            runner: ubuntu-22.04
+          - os: macosx
+            runner: macos-13
+          - os: windows
+            runner: windows-latest
+    runs-on: ${{ matrix.runner }}
+    needs: build
+    env:
+      suffix: '_${{ matrix.os }}-amd64'
+    steps:
+      - name: download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: '**/*${{ env.suffix }}'
+      - name: List files (macos, linux)
+        if: ${{ matrix.os == 'macosx' || matrix.os == 'linux' }}
+        run: ls -laR artifacts/
+      - name: Smoke test each clang tool (macos, linux)
+        if: ${{ matrix.os == 'macosx' || matrix.os == 'linux' }}
+        run: |
+          cd artifacts
+          # From the artifacts directory, loop over each executable
+          # (not .sha512sum files) and
+          # invoke the --version command to verify
+
+          for tool in $(find . -type f); do
+            # Skip the sha512sum files
+            if [[ $tool == *.sha512sum ]]; then
+              continue
+            fi
+            chmod +x $tool
+            # Run the tool with --version and print the output
+            echo "Running $tool --version"
+            $tool --version
+          done
+      - name: List files (Windows)
+        if: ${{ matrix.os == 'windows' }}
+        run: |
+          Get-ChildItem -Recurse artifacts | Format-List
+
+      - name: Smoke test each clang tool (Windows)
+        if: ${{ matrix.os == 'windows' }}
+        shell: pwsh
+        run: |
+          Set-Location artifacts
+
+          # Find all files excluding *.sha512sum
+          $tools = Get-ChildItem -Recurse -File | Where-Object { $_.Name -notlike '*.sha512sum' }
+
+          foreach ($tool in $tools) {
+              # Ensure the file is executable
+              $toolPath = $tool.FullName
+
+              # Print which tool is being run
+              Write-Host "Running $toolPath --version"
+
+              try {
+                  # Attempt to run the tool with --version
+                  & $toolPath --version
+              } catch {
+                  Write-Host "Failed to run $toolPath --version. Error: $_"
+              }
+          }
   draft-release:
     runs-on: ubuntu-22.04
     needs: build
@@ -209,8 +275,6 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          release_name: master-${{ steps.get-sha.outputs.short_sha }}
-          tag: master-${{ steps.get-sha.outputs.short_sha }}
           draft: true
           file_glob: true
           file: clang-*/**/*


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved build workflow for Linux and macOS by reorganizing CMake argument handling and simplifying compiler flags.
  - Enhanced macOS compatibility by updating the deployment target to 10.15 and streamlining patching steps.
  - Added explicit smoke tests for clang tools on all platforms during the build process.
  - Introduced a new test job to verify release artifacts work correctly on Linux, macOS, and Windows.
  - Simplified the draft release step in the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->