### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     types: opened
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     uses: cpp-linter/.github/.github/workflows/pre-commit.yml@main


### PR DESCRIPTION
Potential fix for [https://github.com/cpp-linter/clang-tools-static-binaries/security/code-scanning/1](https://github.com/cpp-linter/clang-tools-static-binaries/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since this is a pre-commit workflow, it likely only needs read access to the repository contents. We will set `contents: read` as the minimal required permission. This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
