### PR TITLE
fix: increase artifact retention-days from 1 to 3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
         name: clang-tools-${{ matrix.release }}-${{ env.suffix }}
         path: "${{ matrix.release }}/build/**/clang-*-${{ env.suffix }}*"
         # ** covers both bin/ (Linux/macOS) and MinSizeRel/bin/ (Windows)
-        retention-days: 1
+        retention-days: 3
   test-release:
     permissions: {}
     strategy:


### PR DESCRIPTION
## Problem

The release `master-69be5937` is missing most clang-version/platform combinations (e.g., all of version 11, and most others).

**Root cause**: The `draft-release` job experienced a ~26-hour queue delay (builds finished May 21 ~16:35 UTC, draft-release ran May 22 ~18:43 UTC). With `retention-days: 1`, nearly all build artifacts expired before the draft-release job could download them. Only 2 of 65 artifacts survived.

```
Found 2 artifact(s)     # expected: 65
```

## Fix

Bump `retention-days` from 1 → 3 to provide adequate buffer for GitHub Actions infrastructure delays.

## Evidence

- [Workflow run 26220685801](https://github.com/cpp-linter/clang-tools-static-binaries/actions/runs/26220685801)
- [Release master-69be5937](https://github.com/cpp-linter/clang-tools-static-binaries/releases/tag/master-69be5937) — 478 assets but missing 5+ versions worth of platform combos