### PR TITLE
fix: remove duplicate versions 12 from build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clang-version: [ 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12.0.1, 12, 11]
+        clang-version: [ 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11]
         platform: [ linux-amd64, linux-arm64, macos-amd64, macos-arm64, windows-amd64 ]
         include:
           - clang-version: 22
@@ -46,10 +46,8 @@ jobs:
             release: llvm-project-14.0.0.src
           - clang-version: 13
             release: llvm-project-13.0.0.src
-          - clang-version: 12.0.1
-            release: llvm-project-12.0.1.src
           - clang-version: 12
-            release: llvm-project-12.0.0.src
+            release: llvm-project-12.0.1.src
           - clang-version: 11
             release: llvm-project-11.1.0.src
           - platform: linux-amd64


### PR DESCRIPTION
Updated clang version entries in the build matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline configuration to standardize LLVM/Clang compiler version handling for consistent builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cpp-linter/clang-tools-static-binaries/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->