### PR TITLE
chore: extract RELEASES mapping into releases.json as single source of truth

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,12 +7,14 @@ on:
       - ".github/workflows/build.yml"
       - "build.py"
       - "release.py"
+      - "releases.json"
   pull_request:
     branches: [ master ]
     paths:
       - ".github/workflows/build.yml"
       - "build.py"
       - "release.py"
+      - "releases.json"
   workflow_dispatch:
 
 concurrency:
@@ -20,58 +22,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  generate-matrix:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    outputs:
+      build-matrix: ${{ steps.set-matrix.outputs.build-matrix }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Generate build matrix from releases.json
+        id: set-matrix
+        run: |
+          MATRIX=$(python3 << 'PYEOF'
+          import json
+          with open('releases.json') as f:
+              releases = json.load(f)
+          platforms = [
+              {'platform': 'linux-amd64', 'os': 'linux', 'arch': 'amd64', 'runner': 'ubuntu-22.04'},
+              {'platform': 'linux-arm64', 'os': 'linux', 'arch': 'arm64', 'runner': 'ubuntu-22.04-arm'},
+              {'platform': 'macos-amd64', 'os': 'macos', 'arch': 'amd64', 'runner': 'macos-15-intel'},
+              {'platform': 'macos-arm64', 'os': 'macos', 'arch': 'arm64', 'runner': 'macos-latest'},
+              {'platform': 'windows-amd64', 'os': 'windows', 'arch': 'amd64', 'runner': 'windows-latest'},
+          ]
+          include = [{'clang-version': v, 'release': r} for v, r in releases.items()]
+          include.extend(platforms)
+          matrix = {
+              'clang-version': sorted(releases.keys(), key=int),
+              'platform': [p['platform'] for p in platforms],
+              'include': include,
+          }
+          print(json.dumps(matrix))
+          PYEOF
+          )
+          printf 'build-matrix=%s\n' "$MATRIX" >> "$GITHUB_OUTPUT"
   build:
+    needs: generate-matrix
     permissions: {}
     strategy:
       fail-fast: false
-      matrix:
-        clang-version: [ 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11]
-        platform: [ linux-amd64, linux-arm64, macos-amd64, macos-arm64, windows-amd64 ]
-        include:
-          - clang-version: 22
-            release: llvm-project-22.1.0.src
-          - clang-version: 21
-            release: llvm-project-21.1.0.src
-          - clang-version: 20
-            release: llvm-project-20.1.0.src
-          - clang-version: 19
-            release: llvm-project-19.1.0.src
-          - clang-version: 18
-            release: llvm-project-18.1.5.src
-          - clang-version: 17
-            release: llvm-project-17.0.6.src
-          - clang-version: 16
-            release: llvm-project-16.0.3.src
-          - clang-version: 15
-            release: llvm-project-15.0.2.src
-          - clang-version: 14
-            release: llvm-project-14.0.0.src
-          - clang-version: 13
-            release: llvm-project-13.0.0.src
-          - clang-version: 12
-            release: llvm-project-12.0.1.src
-          - clang-version: 11
-            release: llvm-project-11.1.0.src
-          - platform: linux-amd64
-            os: linux
-            arch: amd64
-            runner: ubuntu-22.04
-          - platform: linux-arm64
-            os: linux
-            arch: arm64
-            runner: ubuntu-22.04-arm
-          - platform: macos-amd64
-            os: macos
-            arch: amd64
-            runner: macos-15-intel
-          - platform: macos-arm64
-            os: macos
-            arch: arm64
-            runner: macos-latest
-          - platform: windows-amd64
-            os: windows
-            arch: amd64
-            runner: windows-latest
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.build-matrix) }}
     runs-on: ${{ matrix.runner }}
     env:
       RELEASE: '${{ matrix.release }}'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,10 @@ repos:
       - id: check-added-large-files
         args: ['--maxkb=100']
       - id: check-merge-conflict
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,16 +4,17 @@ repos:
     hooks:
       - id: trailing-whitespace
         exclude: '\.patch$'
-      - id: check-yaml
       - id: end-of-file-fixer
         exclude: '\.patch$'
       - id: check-added-large-files
         args: ['--maxkb=100']
       - id: check-merge-conflict
+      - id: check-json
+      - id: check-yaml
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.12
+    rev: v0.15.16
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       - id: ruff-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ The script mirrors exactly what CI does: download LLVM source → configure with
 
 ## Ways to Contribute
 
-- **Add a new clang version** — Update `RELEASES` in `build.py` and the version matrix in `.github/workflows/build.yml`.
+- **Add a new clang version** — Add the version-to-tarball mapping to `releases.json`. The CI matrix is generated automatically from this file.
 - **Fix a build** — Look for failures in the [Build](https://github.com/cpp-linter/clang-tools-static-binaries/actions/workflows/build.yml) workflow.
 - **Improve documentation** — Clarify README, add platform notes, etc.
 

--- a/build.py
+++ b/build.py
@@ -26,6 +26,7 @@ from typing import Any, Literal
 
 import argparse
 import hashlib
+import json
 import os
 import platform
 import subprocess
@@ -35,22 +36,16 @@ import urllib.request
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
-# Version -> source release mapping (must stay in sync with build.yml)
+# Version -> source release mapping (loaded from releases.json)
 # ---------------------------------------------------------------------------
-RELEASES: dict[str, str] = {
-    "22": "llvm-project-22.1.0.src",
-    "21": "llvm-project-21.1.0.src",
-    "20": "llvm-project-20.1.0.src",
-    "19": "llvm-project-19.1.0.src",
-    "18": "llvm-project-18.1.5.src",
-    "17": "llvm-project-17.0.6.src",
-    "16": "llvm-project-16.0.3.src",
-    "15": "llvm-project-15.0.2.src",
-    "14": "llvm-project-14.0.0.src",
-    "13": "llvm-project-13.0.0.src",
-    "12": "llvm-project-12.0.1.src",
-    "11": "llvm-project-11.1.0.src",
-}
+def _load_releases() -> dict[str, str]:
+    """Load the version-to-tarball mapping from releases.json."""
+    releases_path = Path(__file__).parent / "releases.json"
+    with open(releases_path) as f:
+        return json.load(f)
+
+
+RELEASES: dict[str, str] = _load_releases()
 
 TOOLS = ["clang-format", "clang-query", "clang-tidy", "clang-apply-replacements"]
 

--- a/build.py
+++ b/build.py
@@ -35,6 +35,7 @@ import tarfile
 import urllib.request
 from pathlib import Path
 
+
 # ---------------------------------------------------------------------------
 # Version -> source release mapping (loaded from releases.json)
 # ---------------------------------------------------------------------------
@@ -131,9 +132,7 @@ def unpack_tarball(tarball: Path, release: str, extra_excludes: list[str]) -> No
     with tarfile.open(tarball, "r:xz") as tf:
         members = []
         for member in tf.getmembers():
-            skip = any(
-                member.name.startswith(excl.rstrip("*")) for excl in excludes
-            )
+            skip = any(member.name.startswith(excl.rstrip("*")) for excl in excludes)
             if not skip:
                 members.append(member)
         tf.extractall(path=".", members=members)  # noqa: S202 - we own the source
@@ -142,9 +141,7 @@ def unpack_tarball(tarball: Path, release: str, extra_excludes: list[str]) -> No
 def patch_cmake_implicit_link_macos() -> None:
     """Patch brew's CMakeParseImplicitLinkInfo.cmake to recognise gcc_ext."""
     try:
-        brew_prefix = subprocess.check_output(
-            ["brew", "--prefix"], text=True
-        ).strip()
+        brew_prefix = subprocess.check_output(["brew", "--prefix"], text=True).strip()
     except FileNotFoundError:
         print("[warn] brew not found; skipping cmake implicit-link-library patch.")
         return
@@ -326,7 +323,9 @@ def build(version: str, target_platform: str, script_dir: Path) -> None:
         if patch_path.exists():
             apply_patch(patch_path, Path(release))
         else:
-            print(f"[warn] Patch not found at {patch_path}; skipping ARM streaming fix.")
+            print(
+                f"[warn] Patch not found at {patch_path}; skipping ARM streaming fix."
+            )
 
     # ------------------------------------------------------------------
     # 4. CMake configure
@@ -337,8 +336,10 @@ def build(version: str, target_platform: str, script_dir: Path) -> None:
 
     cmake_cmd = [
         "cmake",
-        "-S", str(source_dir),
-        "-B", str(build_dir),
+        "-S",
+        str(source_dir),
+        "-B",
+        str(build_dir),
     ] + CMAKE_ARGS_BY_OS[target_platform]()
 
     run(cmake_cmd)
@@ -346,12 +347,21 @@ def build(version: str, target_platform: str, script_dir: Path) -> None:
     # ------------------------------------------------------------------
     # 5. Build
     # ------------------------------------------------------------------
-    build_cmd = [
-        "cmake", "--build", str(build_dir),
-    ] + build_args_by_os(is_windows) + [
-        "--target",
-        "clang-format", "clang-query", "clang-tidy", "clang-apply-replacements",
-    ]
+    build_cmd = (
+        [
+            "cmake",
+            "--build",
+            str(build_dir),
+        ]
+        + build_args_by_os(is_windows)
+        + [
+            "--target",
+            "clang-format",
+            "clang-query",
+            "clang-tidy",
+            "clang-apply-replacements",
+        ]
+    )
     run(build_cmd)
 
     # ------------------------------------------------------------------

--- a/releases.json
+++ b/releases.json
@@ -1,0 +1,14 @@
+{
+  "22": "llvm-project-22.1.0.src",
+  "21": "llvm-project-21.1.0.src",
+  "20": "llvm-project-20.1.0.src",
+  "19": "llvm-project-19.1.0.src",
+  "18": "llvm-project-18.1.5.src",
+  "17": "llvm-project-17.0.6.src",
+  "16": "llvm-project-16.0.3.src",
+  "15": "llvm-project-15.0.2.src",
+  "14": "llvm-project-14.0.0.src",
+  "13": "llvm-project-13.0.0.src",
+  "12": "llvm-project-12.0.1.src",
+  "11": "llvm-project-11.1.0.src"
+}


### PR DESCRIPTION
Closes #98

## Summary

Extract the `RELEASES` version→tarball mapping into **`releases.json`** so it is the single source of truth used by both `build.py` and the CI matrix.

### Before

- `build.py` had a hardcoded `RELEASES` dict
- `.github/workflows/build.yml` had 12 `include` entries duplicating the same mapping
- Adding a new version required syncing both

### After

- **`releases.json`** – single source of truth for version→tarball
- **`build.py`** – loads from `releases.json` via `_load_releases()`
- **CI** – new `generate-matrix` job reads `releases.json` + outputs dynamic matrix; `build` job consumes it via `fromJson()`
- Adding a new version: just add one line to `releases.json`

### Verifications

- `python3 -c "import build; print(build.RELEASES)"` → 12 versions loaded correctly
- `python3 -c "import release"` → imports OK
- `build.yml` YAML validity checked
- Matrix output: `12 versions × 5 platforms = 60 jobs` (same as before)