### PR TITLE
docs: document releases.json in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,18 @@ The script mirrors exactly what CI does: download LLVM source → configure with
 - **Fix a build** — Look for failures in the [Build](https://github.com/cpp-linter/clang-tools-static-binaries/actions/workflows/build.yml) workflow.
 - **Improve documentation** — Clarify README, add platform notes, etc.
 
+## `releases.json`
+
+[`releases.json`](releases.json) maps clang major versions to LLVM source tarballs:
+
+```json
+{ "22": "llvm-project-22.1.0.src", ... }
+```
+
+The CI matrix, `build.py`, and `release.py` all read from this file. To add a new clang version, add an entry in descending order (newest first) and open a PR — CI will build all platforms automatically.
+
+Each GitHub Release also includes an **immutable** `versions.json` asset (generated from `releases.json` by `release.py`), available at `releases/latest/download/versions.json`.
+
 ## Pull Request Flow
 
 1. Fork the repo and create a branch.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ binaries and their sha512sum files into `<release>/build/bin/`.
 
 ## How can I trust this repository?
 
+- Releases are **immutable** — once published, assets and metadata (`versions.json`) are never modified.
 - Verify sha512sums of binaries against output from GitHub Actions to make sure binaries are not modified
 - Fork this repository and run GitHub actions on your behalf
 - Build and test manually using `python build.py` (see above) or the steps in [.github/workflows](https://github.com/cpp-linter/clang-tools-static-binaries/tree/master/.github/workflows)


### PR DESCRIPTION
## Summary

Documents `releases.json` in CONTRIBUTING.md as requested in #100.

## Changes

- **`releases.json` Structure** — explains the JSON format (major version key → LLVM tarball directory name) with an example
- **How `releases.json` is Used** — a table showing how CI, `build.py`, and `release.py` each consume the file
- **Step-by-step instructions** — 5 steps for adding a new LLVM version (find release tag → determine tarball → edit `releases.json` → test locally → open PR)
- **Immutable Release Metadata** — documents the `versions.json` release asset and the stable `releases/latest/download/versions.json` URL for downstream consumers

Closes #100