### PR TITLE
docs: add back-navigation link to cpp-linter hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # clang-tools static binaries
 
-> [![cpp-linter hub](https://img.shields.io/badge/%F0%9F%8F%A0_cpp--linter_hub-%E2%86%90_home-22863a)](https://cpp-linter.github.io/)
-
 <!-- [![Test](https://github.com/cpp-linter/clang-tools-static-binaries/actions/workflows/test.yml/badge.svg)](https://github.com/cpp-linter/clang-tools-static-binaries/actions/workflows/test.yml) -->
 
 [![Build](https://github.com/cpp-linter/clang-tools-static-binaries/actions/workflows/build.yml/badge.svg)](https://github.com/cpp-linter/clang-tools-static-binaries/actions/workflows/build.yml)
 ![](https://img.shields.io/badge/platform-linux--64%20%7C%20win--64%20%7C%20osx--arm64%20%7C%20osx--64-blue)
-![Maintenance](https://img.shields.io/maintenance/yes/2026)
+[![cpp-linter hub](https://img.shields.io/badge/%F0%9F%8F%A0_cpp--linter_hub-%E2%86%90_home-22863a)](https://cpp-linter.github.io/)
 
 Includes **[clang-format](https://clang.llvm.org/docs/ClangFormat.html), [clang-tidy](https://clang.llvm.org/extra/clang-tidy/), [clang-query](https://github.com/llvm/llvm-project/tree/main/clang-tools-extra/clang-query) and [clang-apply-replacements](https://github.com/llvm/llvm-project/tree/main/clang-tools-extra/clang-apply-replacements)**.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # clang-tools static binaries
 
-> 🏠 [← Back to cpp-linter hub](https://cpp-linter.github.io/)
+> [![cpp-linter hub](https://img.shields.io/badge/%F0%9F%8F%A0_cpp--linter_hub-%E2%86%90_home-22863a)](https://cpp-linter.github.io/)
 
 <!-- [![Test](https://github.com/cpp-linter/clang-tools-static-binaries/actions/workflows/test.yml/badge.svg)](https://github.com/cpp-linter/clang-tools-static-binaries/actions/workflows/test.yml) -->
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # clang-tools static binaries
 
+> 🏠 [← Back to cpp-linter hub](https://cpp-linter.github.io/)
+
 <!-- [![Test](https://github.com/cpp-linter/clang-tools-static-binaries/actions/workflows/test.yml/badge.svg)](https://github.com/cpp-linter/clang-tools-static-binaries/actions/workflows/test.yml) -->
 
 [![Build](https://github.com/cpp-linter/clang-tools-static-binaries/actions/workflows/build.yml/badge.svg)](https://github.com/cpp-linter/clang-tools-static-binaries/actions/workflows/build.yml)


### PR DESCRIPTION
Adds `← Back to cpp-linter hub` link near the top of the README for easier cross-project navigation.