### PR TITLE
feat: add Full Changelog link back to release notes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,7 +182,19 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v8
       - name: Generate versions.json and release notes
-        run: python3 release.py --tag "${{ steps.get-date.outputs.date }}-${{ steps.get-sha.outputs.short_sha }}"
+        env:
+          TAG: "${{ steps.get-date.outputs.date }}-${{ steps.get-sha.outputs.short_sha }}"
+        run: |
+          # Get the previous release tag for the Full Changelog link
+          args=(--tag "$TAG")
+          prev_tag=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // empty')
+          if [[ -n "$prev_tag" ]]; then
+            echo "Previous release tag: $prev_tag"
+            args+=(--previous-tag "$prev_tag")
+          else
+            echo "No previous release found."
+          fi
+          python3 release.py "${args[@]}"
       - name: List files
         run: ls -laR .
       - name: Workaround - delete all files over 2G, above github release file upload limit

--- a/release.py
+++ b/release.py
@@ -41,11 +41,19 @@ def generate_versions_json(tag: str, output_dir: str = ".") -> Path:
     return out_path
 
 
-def generate_release_notes(output_dir: str = ".") -> Path:
+def generate_release_notes(
+    output_dir: str = ".",
+    tag: str | None = None,
+    previous_tag: str | None = None,
+    repo: str = "cpp-linter/clang-tools-static-binaries",
+) -> Path:
     """Write ``release-notes.md`` to *output_dir* and return its path.
 
     The notes include a Markdown table of every LLVM version and its
     corresponding source tarball, plus the list of supported platforms.
+
+    If both *tag* and *previous_tag* are provided, a **Full Changelog**
+    link comparing the previous tag to the current tag is appended.
     """
     lines = [
         "## LLVM Versions in this release",
@@ -66,6 +74,13 @@ def generate_release_notes(output_dir: str = ".") -> Path:
         "",
         "Linux x86-64 / Linux ARM64 / macOS x86-64 / macOS ARM64 / Windows x86-64 / Windows ARM64",
     ]
+
+    if tag and previous_tag:
+        lines += [
+            "",
+            f"**Full Changelog**:"
+            f" https://github.com/{repo}/compare/{previous_tag}...{tag}",
+        ]
 
     out_path = Path(output_dir) / "release-notes.md"
     out_path.parent.mkdir(parents=True, exist_ok=True)
@@ -91,10 +106,22 @@ def main() -> None:
         metavar="DIR",
         help="Directory to write output files (default: current directory).",
     )
+    parser.add_argument(
+        "--previous-tag",
+        default=None,
+        metavar="PREV_TAG",
+        help="Previous release tag for the Full Changelog link.",
+    )
+    parser.add_argument(
+        "--repo",
+        default="cpp-linter/clang-tools-static-binaries",
+        metavar="OWNER/REPO",
+        help="GitHub repository (default: cpp-linter/clang-tools-static-binaries).",
+    )
     args = parser.parse_args()
 
     generate_versions_json(args.tag, args.output_dir)
-    generate_release_notes(args.output_dir)
+    generate_release_notes(args.output_dir, args.tag, args.previous_tag, repo=args.repo)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR adds the **Full Changelog** link back to the generated release notes (fixes #105).

## Changes

### `release.py`
- Accepts new `--previous-tag` and `--repo` CLI options
- When both `--tag` and `--previous-tag` are provided, appends a **Full Changelog** link to the release notes:
  ```
  **Full Changelog**: https://github.com/cpp-linter/clang-tools-static-binaries/compare/<prev>...<current>
  ```

### `.github/workflows/build.yml` (draft-release job)
- Added a step that fetches the previous release tag via `gh release list` and passes it to `release.py --previous-tag`

## Example output

Release notes will now end with:

```markdown
**Full Changelog**: https://github.com/cpp-linter/clang-tools-static-binaries/compare/2026.06.04-a1b2c3d4...2026.06.11-5a535621
```

## Testing

- [x] `python3 release.py --tag mytag --previous-tag oldtag` generates the Full Changelog link
- [x] `python3 release.py --tag mytag` works as before (no link appended)
- [x] CI workflow falls back gracefully if no previous release exists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Release notes now include a full changelog link to compare changes between the current and previous release when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->