### PR TITLE
fix: add GH_TOKEN env to generate versions.json and release notes step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,6 +183,7 @@ jobs:
         uses: actions/download-artifact@v8
       - name: Generate versions.json and release notes
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: "${{ steps.get-date.outputs.date }}-${{ steps.get-sha.outputs.short_sha }}"
           REPO: "${{ github.repository }}"
         run: |


### PR DESCRIPTION
## Problem

The `draft-release` job in `.github/workflows/build.yml` fails with exit code 4:

```
Run python3 release.py --tag $TAG
Created versions.json (12 versions)
Created release-notes.md
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
Error: Process completed with exit code 4.
```

The "Generate versions.json and release notes" step calls `gh release list` to look up the previous release tag for the changelog link, but `GH_TOKEN` was not set in that step's environment.

## Fix

Added `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the step's `env` block, matching what the subsequent "Create draft release and upload assets" step already does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration to improve release process reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->