### PR TITLE
fix: apply CMAKE_POLICY_VERSION_MINIMUM=3.5 for all Windows LLVM 11 builds

### DIFF
--- a/build.py
+++ b/build.py
@@ -355,8 +355,8 @@ def build(version: str, target_platform: str, script_dir: Path) -> None:
     ] + CMAKE_ARGS_BY_OS[target_platform]()
 
     # LLVM 11 requires cmake_minimum_required(VERSION 3.4.3) which is below
-    # the 3.5 floor that newer CMake ships with (windows-11-arm runner).
-    if is_windows and is_arm and version == "11":
+    # the 3.5 floor that newer CMake ships with (Windows runners).
+    if is_windows and version == "11":
         cmake_cmd.append("-DCMAKE_POLICY_VERSION_MINIMUM=3.5")
 
     run(cmake_cmd)


### PR DESCRIPTION
## Problem

The `build (11, windows-amd64)` job in [run #27455372687](https://github.com/cpp-linter/clang-tools-static-binaries/actions/runs/27455372687/job/81248469462) failed with:

```
CMake Error at CMakeLists.txt:3 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
```

## Root Cause

The `windows-latest` runner recently upgraded to Windows Server 2025 with VS2026, which ships a CMake version that has dropped support for `cmake_minimum_required < 3.5`. LLVM 11's `CMakeLists.txt` specifies `cmake_minimum_required(VERSION 3.4.3)`.

The existing workaround (`-DCMAKE_POLICY_VERSION_MINIMUM=3.5`) was gated on `is_arm` (windows-arm64 only), since the ARM runner was the first to get the newer CMake. Now the amd64 runner has been upgraded too.

## Fix

Changed the condition from `is_windows and is_arm and version == "11"` to `is_windows and version == "11"` so the CMake policy minimum is applied for **all** Windows builds of LLVM 11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Windows build configuration for better compatibility and reliability across Windows platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->