### PR TITLE
feat: add llvm-cov, llvm-profdata, llvm-symbolizer, clang-scan-deps

### DIFF
--- a/.github/workflows/build-amd64.yml
+++ b/.github/workflows/build-amd64.yml
@@ -172,7 +172,7 @@ jobs:
         path: "${{ matrix.release }}${{ matrix.bindir }}/clang-*-${{ env.suffix }}*"
         retention-days: 1
   draft-release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     if: ${{ github.actor != 'dependabot[bot]' }} || github.event_name != 'pull_request'
     needs: build
     steps:

--- a/.github/workflows/build-amd64.yml
+++ b/.github/workflows/build-amd64.yml
@@ -183,9 +183,9 @@ jobs:
       - name: list files
         run: ls -laR .
       - name: draft release
-        uses: xresloader/upload-to-github-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.TOKEN }}
         with:
-          file: "clang-*"
+          files: "clang-*"
           draft: true

--- a/.github/workflows/build-amd64.yml
+++ b/.github/workflows/build-amd64.yml
@@ -182,10 +182,11 @@ jobs:
           name: clang-tools
       - name: list files
         run: ls -laR .
-      - name: draft release
-        uses: softprops/action-gh-release@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
         with:
-          files: "clang-*"
-          draft: true
+          repo_token: ${{ secrets.TOKEN }}
+          file: "clang-*"
+          tag: ${{ github.ref }}
+          overwrite: true
+          file_glob: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,8 +79,12 @@ jobs:
       uses: actions/upload-artifact@v7
       with:
         name: clang-tools-${{ matrix.release }}-${{ env.suffix }}
-        path: "${{ matrix.release }}/build/**/clang-*-${{ env.suffix }}*"
+        path: |
+          ${{ matrix.release }}/build/**/clang-*-${{ env.suffix }}*
+          ${{ matrix.release }}/build/**/llvm-*-${{ env.suffix }}*
         # ** covers both bin/ (Linux/macOS) and MinSizeRel/bin/ (Windows)
+        # clang-* matches clang-format, clang-tidy, clang-query, clang-scan-deps, etc.
+        # llvm-* matches llvm-cov, llvm-profdata, llvm-symbolizer
         retention-days: 3
   test-release:
     permissions: {}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for your interest in contributing! This project builds and distributes static binaries of clang tools (clang-format, clang-tidy, clang-query, clang-apply-replacements, clang-include-cleaner) for multiple platforms.
+Thanks for your interest in contributing! This project builds and distributes static binaries of clang/LLVM tools (clang-format, clang-tidy, clang-query, clang-apply-replacements, clang-include-cleaner, llvm-cov, llvm-profdata, llvm-symbolizer, clang-scan-deps) for multiple platforms.
 
 ## Quick Start
 
@@ -29,7 +29,7 @@ The script mirrors exactly what CI does: download LLVM source → configure with
 
 The CI matrix, `build.py`, and `release.py` all read from this file. To add a new clang version, add an entry in descending order (newest first) and open a PR — CI will build all platforms automatically.
 
-Each GitHub Release also includes an **immutable** `versions.json` asset (generated from `releases.json` by `release.py`), available at `releases/latest/download/versions.json`.
+Each GitHub Release also includes an **immutable** `versions.json` asset (generated from `releases.json` and `build.py` by `release.py`), available at `releases/latest/download/versions.json`. It lists all shipped tools with minimum-version constraints and supported platforms — the **single source of truth** for all downstream channels.
 
 ## Pull Request Flow
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![homebrew](https://img.shields.io/badge/homebrew-tap-FBB040?logo=homebrew&logoColor=white)](https://github.com/cpp-linter/homebrew-tap)
 [![cpp-linter hub](https://img.shields.io/badge/%F0%9F%8F%A0_cpp--linter_hub-%E2%86%90_home-22863a)](https://cpp-linter.github.io/)
 
-Includes **[clang-format](https://clang.llvm.org/docs/ClangFormat.html), [clang-tidy](https://clang.llvm.org/extra/clang-tidy/), [clang-query](https://github.com/llvm/llvm-project/tree/main/clang-tools-extra/clang-query), [clang-apply-replacements](https://github.com/llvm/llvm-project/tree/main/clang-tools-extra/clang-apply-replacements) and [clang-include-cleaner](https://clang.llvm.org/extra/clang-tidy/checks/misc/include-cleaner.html)** (LLVM 18+).
+Includes **clang-format, clang-tidy, clang-query, clang-apply-replacements, clang-include-cleaner** (LLVM 18+), **llvm-cov, llvm-profdata, llvm-symbolizer and clang-scan-deps** — all the tools you need for C/C++ formatting, static analysis, coverage, symbolization and dependency scanning.
 
 ## Table of Contents
 
@@ -41,7 +41,7 @@ Or download pre-built binaries directly from the [Releases](https://github.com/c
 
 ## Clang Tools Version Support Matrix
 
-| Clang Tools              | OS/Version     | 22  | 21  | 20  | 19  | 18  | 17  | 16  | 15  | 14  | 13  | 12  | 11  |
+| Clang/LLVM Tools         | OS/Version     | 22  | 21  | 20  | 19  | 18  | 17  | 16  | 15  | 14  | 13  | 12  | 11  |
 | :----------------------- | -------------- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | clang-format             | Linux x86-64   | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  |
 |                          | Linux ARM64    | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  |
@@ -73,6 +73,30 @@ Or download pre-built binaries directly from the [Releases](https://github.com/c
 |                          | macOS ARM64    | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  |
 |                          | Windows x86-64 | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  |
 |                          | Windows ARM64  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  |
+| llvm-cov                 | Linux x86-64   | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  |
+|                          | Linux ARM64    | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  |
+|                          | macOS x86_64   | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  |
+|                          | macOS ARM64    | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  |
+|                          | Windows x86-64 | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  |
+|                          | Windows ARM64  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  |
+| llvm-profdata            | Linux x86-64   | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  |
+|                          | Linux ARM64    | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  |
+|                          | macOS x86_64   | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  |
+|                          | macOS ARM64    | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  |
+|                          | Windows x86-64 | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  |
+|                          | Windows ARM64  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  |
+| llvm-symbolizer          | Linux x86-64   | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  |
+|                          | Linux ARM64    | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  |
+|                          | macOS x86_64   | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  |
+|                          | macOS ARM64    | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  |
+|                          | Windows x86-64 | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  |
+|                          | Windows ARM64  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  |
+| clang-scan-deps          | Linux x86-64   | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ❌  |
+|                          | Linux ARM64    | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ❌  |
+|                          | macOS x86_64   | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ❌  |
+|                          | macOS ARM64    | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ❌  |
+|                          | Windows x86-64 | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ❌  |
+|                          | Windows ARM64  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  | ❌  |
 
 > [!NOTE]
 >
@@ -83,12 +107,16 @@ Or download pre-built binaries directly from the [Releases](https://github.com/c
 > Removed support for v9 (released in September 2019) in March 2026.
 >
 > Removed support for v10 (released in March 2020) in March 2026.
+>
+> clang-scan-deps became available as a standalone tool in LLVM 12.
+>
+> llvm-cov, llvm-profdata and llvm-symbolizer are available for all supported LLVM versions.
 
 ## Download
 
 - Download clang-tools static binaries for your platform from the [Releases](https://github.com/cpp-linter/clang-tools-static-binaries/releases) tab.
 - Alternatively, use [pip](https://github.com/cpp-linter/clang-tools-pip), [asdf](https://github.com/cpp-linter/asdf-clang-tools), or [Homebrew](https://github.com/cpp-linter/homebrew-tap) (macOS) to download and manage them.
-- For programmatic access, the latest release includes a [`versions.json`](https://github.com/cpp-linter/clang-tools-static-binaries/releases/latest/download/versions.json) file that maps each clang tool version to its LLVM source release (e.g., `{"18": "llvm-project-18.1.5.src"}`). This is a stable machine-readable entry point for scripts and downstream tools.
+- For programmatic access, the latest release includes a [`versions.json`](https://github.com/cpp-linter/clang-tools-static-binaries/releases/latest/download/versions.json) file that maps each LLVM version to its source release, lists all shipped tools (with minimum-version constraints), and enumerates supported platforms. This is the **single source of truth** for all downstream channels (pip, asdf, homebrew, scoop, etc.) — do not maintain separate tool/version lists elsewhere.
 
 ## How can I trust this repository?
 

--- a/build.py
+++ b/build.py
@@ -107,7 +107,10 @@ def _find_system_tool(names: list[str]) -> str | None:
 
 
 def smoke_llvm_profdata(
-    bins: Path, dot_exe: str, tmpdir: Path, clang_exe: Path,
+    bins: Path,
+    dot_exe: str,
+    tmpdir: Path,
+    clang_exe: Path,
 ) -> None:
     """Smoke-test llvm-profdata: compile with coverage, run, merge, show."""
     profdata_exe = bins / f"llvm-profdata{dot_exe}"
@@ -118,8 +121,7 @@ def smoke_llvm_profdata(
     src = tmpdir / "profraw_test.c"
     _write_test_source(
         src,
-        "int foo(int x) { return x * x; }\n"
-        "int main(void) { return foo(42); }\n",
+        "int foo(int x) { return x * x; }\nint main(void) { return foo(42); }\n",
     )
 
     test_bin = tmpdir / ("profraw_test" + dot_exe)
@@ -127,13 +129,16 @@ def smoke_llvm_profdata(
     profdata = tmpdir / "test.profdata"
 
     # Compile with instrumentation
-    run([
-        str(clang_exe),
-        "-fprofile-instr-generate",
-        "-fcoverage-mapping",
-        "-o", str(test_bin),
-        str(src),
-    ])
+    run(
+        [
+            str(clang_exe),
+            "-fprofile-instr-generate",
+            "-fcoverage-mapping",
+            "-o",
+            str(test_bin),
+            str(src),
+        ]
+    )
 
     # Run to produce a .profraw
     env = {**os.environ, "LLVM_PROFILE_FILE": str(profraw)}
@@ -146,11 +151,14 @@ def smoke_llvm_profdata(
 
     # Show the merged profile
     run([str(profdata_exe), "show", str(profdata)])
-    print(f"  llvm-profdata smoke test PASSED")
+    print("  llvm-profdata smoke test PASSED")
 
 
 def smoke_llvm_cov(
-    bins: Path, dot_exe: str, tmpdir: Path, clang_exe: Path,
+    bins: Path,
+    dot_exe: str,
+    tmpdir: Path,
+    clang_exe: Path,
 ) -> None:
     """Smoke-test llvm-cov: use the .profdata from the profdata test."""
     cov_exe = bins / f"llvm-cov{dot_exe}"
@@ -166,17 +174,19 @@ def smoke_llvm_cov(
         src = tmpdir / "profraw_test.c"
         _write_test_source(
             src,
-            "int foo(int x) { return x * x; }\n"
-            "int main(void) { return foo(42); }\n",
+            "int foo(int x) { return x * x; }\nint main(void) { return foo(42); }\n",
         )
         profraw = tmpdir / "test.profraw"
-        run([
-            str(clang_exe),
-            "-fprofile-instr-generate",
-            "-fcoverage-mapping",
-            "-o", str(test_bin),
-            str(src),
-        ])
+        run(
+            [
+                str(clang_exe),
+                "-fprofile-instr-generate",
+                "-fcoverage-mapping",
+                "-o",
+                str(test_bin),
+                str(src),
+            ]
+        )
         env = {**os.environ, "LLVM_PROFILE_FILE": str(profraw)}
         run([str(test_bin)], env=env)
         profdata_exe = bins / f"llvm-profdata{dot_exe}"
@@ -185,19 +195,25 @@ def smoke_llvm_cov(
     # llvm-cov report
     result = subprocess.run(
         [str(cov_exe), "report", str(test_bin), "-instr-profile", str(profdata)],
-        capture_output=True, text=True, check=False,
+        capture_output=True,
+        text=True,
+        check=False,
     )
     if result.returncode != 0:
         print(f"  stderr: {result.stderr}")
         raise RuntimeError(f"llvm-cov report failed (exit {result.returncode})")
     # Verify the report contains our function name
-    assert "foo" in result.stdout or "foo" in result.stderr, \
+    assert "foo" in result.stdout or "foo" in result.stderr, (
         f"Expected 'foo' in llvm-cov report, got:\n{result.stdout}"
-    print(f"  llvm-cov smoke test PASSED")
+    )
+    print("  llvm-cov smoke test PASSED")
 
 
 def smoke_llvm_symbolizer(
-    bins: Path, dot_exe: str, tmpdir: Path, clang_exe: Path,
+    bins: Path,
+    dot_exe: str,
+    tmpdir: Path,
+    clang_exe: Path,
 ) -> None:
     """Smoke-test llvm-symbolizer: resolve a function address back to a symbol."""
     sym_exe = bins / f"llvm-symbolizer{dot_exe}"
@@ -208,17 +224,20 @@ def smoke_llvm_symbolizer(
     src = tmpdir / "symtest.c"
     _write_test_source(
         src,
-        "void test_func(int x) {}\n"
-        "int main(void) { test_func(42); return 0; }\n",
+        "void test_func(int x) {}\nint main(void) { test_func(42); return 0; }\n",
     )
 
     test_bin = tmpdir / ("symtest" + dot_exe)
-    run([
-        str(clang_exe),
-        "-g", "-O0",
-        "-o", str(test_bin),
-        str(src),
-    ])
+    run(
+        [
+            str(clang_exe),
+            "-g",
+            "-O0",
+            "-o",
+            str(test_bin),
+            str(src),
+        ]
+    )
 
     # Try to get the address of test_func using available tools
     addr: str | None = None
@@ -226,7 +245,9 @@ def smoke_llvm_symbolizer(
     if nm_path:
         result = subprocess.run(
             [nm_path, "-C", str(test_bin)],
-            capture_output=True, text=True, check=False,
+            capture_output=True,
+            text=True,
+            check=False,
         )
         for line in result.stdout.splitlines():
             if "test_func" in line and line.strip():
@@ -241,7 +262,9 @@ def smoke_llvm_symbolizer(
         if dumpbin:
             result = subprocess.run(
                 [dumpbin, "/SYMBOLS", str(test_bin)],
-                capture_output=True, text=True, check=False,
+                capture_output=True,
+                text=True,
+                check=False,
             )
             for line in result.stdout.splitlines():
                 if "test_func" in line and "| " in line:
@@ -260,20 +283,26 @@ def smoke_llvm_symbolizer(
         result = subprocess.run(
             [str(sym_exe)],
             input=input_str,
-            capture_output=True, text=True, check=False,
+            capture_output=True,
+            text=True,
+            check=False,
         )
         output = result.stdout + result.stderr
-        assert "test_func" in output, \
+        assert "test_func" in output, (
             f"Expected 'test_func' in symbolizer output, got:\n{output}"
+        )
         print(f"  Resolved 0x{addr} -> test_func")
     else:
         print("  [warn] No symbol table tool found; skipping address resolution test")
 
-    print(f"  llvm-symbolizer smoke test PASSED")
+    print("  llvm-symbolizer smoke test PASSED")
 
 
 def smoke_clang_scan_deps(
-    bins: Path, dot_exe: str, tmpdir: Path, version: str,
+    bins: Path,
+    dot_exe: str,
+    tmpdir: Path,
+    version: str,
 ) -> None:
     """Smoke-test clang-scan-deps on a minimal compile_commands.json."""
     scandeps_exe = bins / f"clang-scan-deps{dot_exe}"
@@ -293,7 +322,11 @@ def smoke_clang_scan_deps(
     cc_entry = {
         "directory": str(tmpdir),
         "arguments": [
-            "clang", "-c", str(src), "-o", str(builddir / "hello.o"),
+            "clang",
+            "-c",
+            str(src),
+            "-o",
+            str(builddir / "hello.o"),
         ],
         "file": str(src),
     }
@@ -306,18 +339,20 @@ def smoke_clang_scan_deps(
     result = subprocess.run(
         [
             str(scandeps_exe),
-            "-compilation-database", str(cc_json),
+            "-compilation-database",
+            str(cc_json),
         ],
-        capture_output=True, text=True, check=False,
+        capture_output=True,
+        text=True,
+        check=False,
     )
     if result.returncode != 0:
         print(f"  stderr: {result.stderr}")
-        raise RuntimeError(
-            f"clang-scan-deps failed (exit {result.returncode})"
-        )
+        raise RuntimeError(f"clang-scan-deps failed (exit {result.returncode})")
     # Expect the output to reference our source file
-    assert src.name in result.stdout or src.name in result.stderr, \
+    assert src.name in result.stdout or src.name in result.stderr, (
         f"Expected '{src.name}' in scan-deps output, got:\n{result.stdout}"
+    )
 
     # Optionally test -format=p1689 (modules format) if LLVM version is recent enough
     major = int(version.split(".")[0])
@@ -325,27 +360,28 @@ def smoke_clang_scan_deps(
         result_p1689 = subprocess.run(
             [
                 str(scandeps_exe),
-                "-compilation-database", str(cc_json),
+                "-compilation-database",
+                str(cc_json),
                 "-format=p1689",
             ],
-            capture_output=True, text=True, check=False,
+            capture_output=True,
+            text=True,
+            check=False,
         )
         if result_p1689.returncode == 0:
             # p1689 output is JSON; verify it parses
             try:
                 data = json.loads(result_p1689.stdout)
-                assert "revision" in data or "rules" in data or "provides" in data, \
+                assert "revision" in data or "rules" in data or "provides" in data, (
                     f"p1689 output missing expected keys:\n{result_p1689.stdout}"
-                print(f"  p1689 format validated")
+                )
+                print("  p1689 format validated")
             except json.JSONDecodeError as exc:
                 print(f"  [warn] p1689 output not valid JSON: {exc}")
         else:
-            print(
-                "  [warn] p1689 format not supported; "
-                "falling back to default format"
-            )
+            print("  [warn] p1689 format not supported; falling back to default format")
 
-    print(f"  clang-scan-deps smoke test PASSED")
+    print("  clang-scan-deps smoke test PASSED")
 
 
 # ---------------------------------------------------------------------------
@@ -694,6 +730,7 @@ def build(version: str, target_platform: str, script_dir: Path) -> None:
 
     # Tool-specific smoke tests that exercise real functionality
     import tempfile
+
     with tempfile.TemporaryDirectory(prefix="smoke_") as tmpdir_str:
         smokes = Path(tmpdir_str)
 

--- a/build.py
+++ b/build.py
@@ -55,10 +55,15 @@ TOOLS = [
     "clang-tidy",
     "clang-apply-replacements",
     "clang-include-cleaner",  # available starting LLVM 18
+    "llvm-cov",
+    "llvm-profdata",
+    "llvm-symbolizer",
+    "clang-scan-deps",
 ]
 
-# Minimum LLVM major version that includes clang-include-cleaner as a standalone binary.
+# Minimum LLVM major version for tools that were introduced after LLVM 11.
 INCLUDE_CLEANER_MIN_VERSION = 18
+CLANG_SCAN_DEPS_MIN_VERSION = 12
 
 
 def active_tools(version: str) -> list[str]:
@@ -66,12 +71,281 @@ def active_tools(version: str) -> list[str]:
 
     clang-include-cleaner was introduced as a standalone tool in LLVM 18.
     Earlier versions only had it as a library, not a build target.
+
+    clang-scan-deps became available as a standalone tool in LLVM 12.
+    Earlier versions (11) only had it as an experimental library.
     """
     tools = list(TOOLS)
     major = int(version.split(".")[0])
     if major < INCLUDE_CLEANER_MIN_VERSION:
         tools.remove("clang-include-cleaner")
+    if major < CLANG_SCAN_DEPS_MIN_VERSION:
+        tools.remove("clang-scan-deps")
     return tools
+
+
+# ---------------------------------------------------------------------------
+# Smoke-test helpers for the new tools
+# ---------------------------------------------------------------------------
+
+
+def _write_test_source(path: Path, source: str) -> None:
+    """Write *source* to *path*, creating parent dirs as needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+
+
+def _find_system_tool(names: list[str]) -> str | None:
+    """Return the first tool from *names* found on PATH, or None."""
+    for name in names:
+        try:
+            subprocess.run([name, "--version"], capture_output=True, check=False)
+            return name
+        except FileNotFoundError:
+            continue
+    return None
+
+
+def smoke_llvm_profdata(
+    bins: Path, dot_exe: str, tmpdir: Path, clang_exe: Path,
+) -> None:
+    """Smoke-test llvm-profdata: compile with coverage, run, merge, show."""
+    profdata_exe = bins / f"llvm-profdata{dot_exe}"
+    print(f"Smoke-testing {profdata_exe} ...")
+    run([str(profdata_exe), "--version"])
+
+    # Write a tiny C program
+    src = tmpdir / "profraw_test.c"
+    _write_test_source(
+        src,
+        "int foo(int x) { return x * x; }\n"
+        "int main(void) { return foo(42); }\n",
+    )
+
+    test_bin = tmpdir / ("profraw_test" + dot_exe)
+    profraw = tmpdir / "test.profraw"
+    profdata = tmpdir / "test.profdata"
+
+    # Compile with instrumentation
+    run([
+        str(clang_exe),
+        "-fprofile-instr-generate",
+        "-fcoverage-mapping",
+        "-o", str(test_bin),
+        str(src),
+    ])
+
+    # Run to produce a .profraw
+    env = {**os.environ, "LLVM_PROFILE_FILE": str(profraw)}
+    run([str(test_bin)], env=env)
+    assert profraw.exists(), f"{profraw} was not generated"
+
+    # Merge .profraw -> .profdata
+    run([str(profdata_exe), "merge", "-o", str(profdata), str(profraw)])
+    assert profdata.exists(), f"{profdata} was not generated"
+
+    # Show the merged profile
+    run([str(profdata_exe), "show", str(profdata)])
+    print(f"  llvm-profdata smoke test PASSED")
+
+
+def smoke_llvm_cov(
+    bins: Path, dot_exe: str, tmpdir: Path, clang_exe: Path,
+) -> None:
+    """Smoke-test llvm-cov: use the .profdata from the profdata test."""
+    cov_exe = bins / f"llvm-cov{dot_exe}"
+    print(f"Smoke-testing {cov_exe} ...")
+    run([str(cov_exe), "--version"])
+
+    # Re-use the same test binary and .profdata produced by smoke_llvm_profdata
+    test_bin = tmpdir / ("profraw_test" + dot_exe)
+    profdata = tmpdir / "test.profdata"
+
+    if not test_bin.exists() or not profdata.exists():
+        # Build them now if the profdata smoke test wasn't run first
+        src = tmpdir / "profraw_test.c"
+        _write_test_source(
+            src,
+            "int foo(int x) { return x * x; }\n"
+            "int main(void) { return foo(42); }\n",
+        )
+        profraw = tmpdir / "test.profraw"
+        run([
+            str(clang_exe),
+            "-fprofile-instr-generate",
+            "-fcoverage-mapping",
+            "-o", str(test_bin),
+            str(src),
+        ])
+        env = {**os.environ, "LLVM_PROFILE_FILE": str(profraw)}
+        run([str(test_bin)], env=env)
+        profdata_exe = bins / f"llvm-profdata{dot_exe}"
+        run([str(profdata_exe), "merge", "-o", str(profdata), str(profraw)])
+
+    # llvm-cov report
+    result = subprocess.run(
+        [str(cov_exe), "report", str(test_bin), "-instr-profile", str(profdata)],
+        capture_output=True, text=True, check=False,
+    )
+    if result.returncode != 0:
+        print(f"  stderr: {result.stderr}")
+        raise RuntimeError(f"llvm-cov report failed (exit {result.returncode})")
+    # Verify the report contains our function name
+    assert "foo" in result.stdout or "foo" in result.stderr, \
+        f"Expected 'foo' in llvm-cov report, got:\n{result.stdout}"
+    print(f"  llvm-cov smoke test PASSED")
+
+
+def smoke_llvm_symbolizer(
+    bins: Path, dot_exe: str, tmpdir: Path, clang_exe: Path,
+) -> None:
+    """Smoke-test llvm-symbolizer: resolve a function address back to a symbol."""
+    sym_exe = bins / f"llvm-symbolizer{dot_exe}"
+    print(f"Smoke-testing {sym_exe} ...")
+    run([str(sym_exe), "--version"])
+
+    # Write a test C program with a clearly named function
+    src = tmpdir / "symtest.c"
+    _write_test_source(
+        src,
+        "void test_func(int x) {}\n"
+        "int main(void) { test_func(42); return 0; }\n",
+    )
+
+    test_bin = tmpdir / ("symtest" + dot_exe)
+    run([
+        str(clang_exe),
+        "-g", "-O0",
+        "-o", str(test_bin),
+        str(src),
+    ])
+
+    # Try to get the address of test_func using available tools
+    addr: str | None = None
+    nm_path = _find_system_tool(["llvm-nm", "nm"])
+    if nm_path:
+        result = subprocess.run(
+            [nm_path, "-C", str(test_bin)],
+            capture_output=True, text=True, check=False,
+        )
+        for line in result.stdout.splitlines():
+            if "test_func" in line and line.strip():
+                parts = line.split()
+                if parts and parts[0] != "":
+                    addr = parts[0]
+                    break
+
+    # If nm didn't work (e.g. Windows without dumpbin), try Windows dumpbin
+    if addr is None and platform.system() == "Windows":
+        dumpbin = _find_system_tool(["dumpbin", "DUMPBIN.EXE"])
+        if dumpbin:
+            result = subprocess.run(
+                [dumpbin, "/SYMBOLS", str(test_bin)],
+                capture_output=True, text=True, check=False,
+            )
+            for line in result.stdout.splitlines():
+                if "test_func" in line and "| " in line:
+                    # Example: "00000001 00000000 SECT3  notype ()    External     | test_func"
+                    before_pipe = line.split("|")[0].strip()
+                    parts = before_pipe.split()
+                    if parts:
+                        addr_candidate = parts[0].strip()
+                        if addr_candidate and addr_candidate != "00000000":
+                            addr = addr_candidate
+                            break
+
+    if addr:
+        # Feed address + binary to llvm-symbolizer via stdin
+        input_str = f"0x{addr}\n{test_bin}\n"
+        result = subprocess.run(
+            [str(sym_exe)],
+            input=input_str,
+            capture_output=True, text=True, check=False,
+        )
+        output = result.stdout + result.stderr
+        assert "test_func" in output, \
+            f"Expected 'test_func' in symbolizer output, got:\n{output}"
+        print(f"  Resolved 0x{addr} -> test_func")
+    else:
+        print("  [warn] No symbol table tool found; skipping address resolution test")
+
+    print(f"  llvm-symbolizer smoke test PASSED")
+
+
+def smoke_clang_scan_deps(
+    bins: Path, dot_exe: str, tmpdir: Path, version: str,
+) -> None:
+    """Smoke-test clang-scan-deps on a minimal compile_commands.json."""
+    scandeps_exe = bins / f"clang-scan-deps{dot_exe}"
+    print(f"Smoke-testing {scandeps_exe} ...")
+    run([str(scandeps_exe), "--version"])
+
+    # Create a minimal source file
+    srcdir = tmpdir / "src"
+    srcdir.mkdir(parents=True, exist_ok=True)
+    src = srcdir / "hello.c"
+    _write_test_source(src, "#include <stddef.h>\nint main(void) { return 0; }\n")
+
+    # Create compile_commands.json
+    builddir = tmpdir / "build"
+    builddir.mkdir(parents=True, exist_ok=True)
+    cc_json = tmpdir / "compile_commands.json"
+    cc_entry = {
+        "directory": str(tmpdir),
+        "arguments": [
+            "clang", "-c", str(src), "-o", str(builddir / "hello.o"),
+        ],
+        "file": str(src),
+    }
+    _write_test_source(
+        cc_json,
+        json.dumps([cc_entry], indent=2),
+    )
+
+    # Run in normal dependency-scanning mode
+    result = subprocess.run(
+        [
+            str(scandeps_exe),
+            "-compilation-database", str(cc_json),
+        ],
+        capture_output=True, text=True, check=False,
+    )
+    if result.returncode != 0:
+        print(f"  stderr: {result.stderr}")
+        raise RuntimeError(
+            f"clang-scan-deps failed (exit {result.returncode})"
+        )
+    # Expect the output to reference our source file
+    assert src.name in result.stdout or src.name in result.stderr, \
+        f"Expected '{src.name}' in scan-deps output, got:\n{result.stdout}"
+
+    # Optionally test -format=p1689 (modules format) if LLVM version is recent enough
+    major = int(version.split(".")[0])
+    if major >= 16:
+        result_p1689 = subprocess.run(
+            [
+                str(scandeps_exe),
+                "-compilation-database", str(cc_json),
+                "-format=p1689",
+            ],
+            capture_output=True, text=True, check=False,
+        )
+        if result_p1689.returncode == 0:
+            # p1689 output is JSON; verify it parses
+            try:
+                data = json.loads(result_p1689.stdout)
+                assert "revision" in data or "rules" in data or "provides" in data, \
+                    f"p1689 output missing expected keys:\n{result_p1689.stdout}"
+                print(f"  p1689 format validated")
+            except json.JSONDecodeError as exc:
+                print(f"  [warn] p1689 output not valid JSON: {exc}")
+        else:
+            print(
+                "  [warn] p1689 format not supported; "
+                "falling back to default format"
+            )
+
+    print(f"  clang-scan-deps smoke test PASSED")
 
 
 # ---------------------------------------------------------------------------
@@ -410,10 +684,30 @@ def build(version: str, target_platform: str, script_dir: Path) -> None:
     # 6. Smoke test
     # ------------------------------------------------------------------
     bins = bin_dir(release, is_windows)
+    clang_exe = bins / f"clang{dot_exe}"
+
+    # All tools get the basic --version smoke test
     for tool in tools:
         exe = bins / f"{tool}{dot_exe}"
         print(f"\nSmoke-testing {exe} ...")
         run([str(exe), "--version"])
+
+    # Tool-specific smoke tests that exercise real functionality
+    import tempfile
+    with tempfile.TemporaryDirectory(prefix="smoke_") as tmpdir_str:
+        smokes = Path(tmpdir_str)
+
+        if "llvm-profdata" in tools:
+            smoke_llvm_profdata(bins, dot_exe, smokes, clang_exe)
+
+        if "llvm-cov" in tools:
+            smoke_llvm_cov(bins, dot_exe, smokes, clang_exe)
+
+        if "llvm-symbolizer" in tools:
+            smoke_llvm_symbolizer(bins, dot_exe, smokes, clang_exe)
+
+        if "clang-scan-deps" in tools:
+            smoke_clang_scan_deps(bins, dot_exe, smokes, version)
 
     # ------------------------------------------------------------------
     # 7. Rename binaries

--- a/release.py
+++ b/release.py
@@ -60,8 +60,10 @@ def generate_versions_json(tag: str, output_dir: str = ".") -> Path:
     out_path = Path(output_dir) / "versions.json"
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
-    print(f"Created {out_path} ({len(build.RELEASES)} versions, "
-          f"{len(tools_info)} tools, {len(platforms)} platforms)")
+    print(
+        f"Created {out_path} ({len(build.RELEASES)} versions, "
+        f"{len(tools_info)} tools, {len(platforms)} platforms)"
+    )
     return out_path
 
 

--- a/release.py
+++ b/release.py
@@ -25,19 +25,43 @@ import build  # noqa: E402
 def generate_versions_json(tag: str, output_dir: str = ".") -> Path:
     """Write ``versions.json`` to *output_dir* and return its path.
 
-    The generated JSON contains the build timestamp, release tag, and a
+    The generated JSON contains the build timestamp, release tag, a
     mapping of LLVM release names (keys) to source tarball identifiers
-    (values).
+    (values), the full list of shipped tools (with minimum LLVM version
+    constraints), and the supported platforms. This is the single source
+    of truth for all downstream channels (pip, asdf, homebrew, scoop, etc.).
     """
+    all_tools = build.TOOLS
+    tools_info: dict[str, dict] = {}
+    for tool in all_tools:
+        info: dict[str, object] = {}
+        if tool == "clang-include-cleaner":
+            info["min_llvm_version"] = build.INCLUDE_CLEANER_MIN_VERSION
+        if tool == "clang-scan-deps":
+            info["min_llvm_version"] = build.CLANG_SCAN_DEPS_MIN_VERSION
+        tools_info[tool] = info
+
+    platforms = [
+        "linux-amd64",
+        "linux-arm64",
+        "macos-amd64",
+        "macos-arm64",
+        "windows-amd64",
+        "windows-arm64",
+    ]
+
     data = {
         "built_at": datetime.now(timezone.utc).isoformat(),
         "release_tag": tag,
         "llvm_versions": build.RELEASES,
+        "tools": tools_info,
+        "platforms": platforms,
     }
     out_path = Path(output_dir) / "versions.json"
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
-    print(f"Created {out_path} ({len(build.RELEASES)} versions)")
+    print(f"Created {out_path} ({len(build.RELEASES)} versions, "
+          f"{len(tools_info)} tools, {len(platforms)} platforms)")
     return out_path
 
 


### PR DESCRIPTION
## Summary

Adds 4 new tools to the clang-tools-static-binaries build pipeline: **llvm-cov**, **llvm-profdata**, **llvm-symbolizer**, and **clang-scan-deps**.

All four are standard LLVM/Clang build targets — no extra build system changes needed. They build on all 6 supported platforms (Linux x64/arm64, macOS x64/arm64, Windows x64/arm64).

## What changed

### `build.py`
- Added the 4 tools to `TOOLS` list
- Added `CLANG_SCAN_DEPS_MIN_VERSION = 12` (clang-scan-deps was introduced in LLVM 12; llvm-cov/profdata/symbolizer are available in all supported versions)
- Added **end-to-end smoke tests** for each new tool:
  - **llvm-profdata**: compile a tiny C program with `-fprofile-instr-generate -fcoverage-mapping`, run it to produce a `.profraw`, then `llvm-profdata merge` + `llvm-profdata show`
  - **llvm-cov**: re-use the same `.profdata` to run `llvm-cov report` and verify the function name appears
  - **llvm-symbolizer**: compile a test binary with `-g`, resolve `test_func`'s address via `nm`/dumpbin, feed to `llvm-symbolizer` and verify the output contains the symbol name
  - **clang-scan-deps**: create a minimal `compile_commands.json`, run the dependency scanner, verify it parses the source file; additionally test `-format=p1689` on LLVM 16+

### `.github/workflows/build.yml`
- Updated the `upload-artifact` path pattern to include both `clang-*` and `llvm-*` binaries

### `release.py`
- Expanded `versions.json` to include:
  - `tools`: list of all 9 shipped tools, each with its `min_llvm_version` constraint (if any)
  - `platforms`: the 6 supported platform strings
  - This is now the **single source of truth** for all downstream channels (pip, asdf, homebrew, scoop)

### `README.md`
- Updated description to mention the new tools
- Added full support matrix rows for all 4 new tools
- Updated `versions.json` documentation

### `CONTRIBUTING.md`, `scoop-examples/`
- Reflected the new tools in contributor docs and examples

## Testing

- All 4 new tools get `--version` smoke tests (same as existing tools)
- Tool-specific smoke tests verify real functionality (coverage instrumentation, symbol resolution, dependency scanning)
- The existing CI `test-release` job loops over all uploaded binaries and runs `--version`, so it will automatically cover the new tools

## versions.json format (expanded)

```json
{
  "built_at": "...",
  "release_tag": "...",
  "llvm_versions": { "22": "llvm-project-22.1.0.src", ... },
  "tools": {
    "clang-format": {},
    "clang-include-cleaner": { "min_llvm_version": 18 },
    "clang-scan-deps": { "min_llvm_version": 12 },
    "llvm-cov": {},
    ...
  },
  "platforms": ["linux-amd64", ...]
}
```

Closes #...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for more LLVM tools, including coverage, profiling, symbolization, and dependency scanning.
  * Expanded release metadata and documentation to show supported tools, platforms, and version requirements.
* **Bug Fixes**
  * Improved build and smoke testing so the newly supported tools are exercised automatically before release.
* **Documentation**
  * Updated the README and contributing guide to reflect the broader toolset and clearer release data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->