### PR TITLE
docs: document version support and retirement policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,9 +27,33 @@ The script mirrors exactly what CI does: download LLVM source → configure with
 { "22": "llvm-project-22.1.0.src", ... }
 ```
 
-The CI matrix, `build.py`, and `release.py` all read from this file. To add a new clang version, add an entry in descending order (newest first) and open a PR — CI will build all platforms automatically.
+The CI matrix, `build.py`, and `release.py` all read from this file.
 
-Each GitHub Release also includes an **immutable** `versions.json` asset (generated from `releases.json` by `release.py`), available at `releases/latest/download/versions.json`.
+### Adding a new LLVM version
+
+1. Add an entry to `releases.json` in descending order (newest first).
+2. Open a PR — CI will build all platforms automatically.
+3. Always test at least one platform locally before opening the PR.
+
+### Version retirement policy
+
+To keep build times and release sizes manageable, the project maintains a
+**rolling window of the latest LLVM major versions**. When a new version is
+added, the oldest one should be retired in the same PR.
+
+**Rule of thumb:** Keep the latest 6–8 major versions. When adding version `N`,
+remove version `N-8` (or older) from `releases.json`. Check the
+[README](README.md) for the current retirement history.
+
+Retiring a version does **not** delete its binaries from previous releases.
+Historical assets remain on GitHub Releases indefinitely.
+
+### New tools and older LLVM versions
+
+Some tools (e.g., `clang-include-cleaner`) only exist as standalone build targets
+in newer LLVM releases. This is a fundamental limitation of the upstream source —
+the project does not attempt to backport tools to older LLVM versions. The
+version support matrix in the README uses ❌ to clearly mark these gaps.
 
 ## Pull Request Flow
 
@@ -38,7 +62,7 @@ Each GitHub Release also includes an **immutable** `versions.json` asset (genera
 3. Test locally with `python build.py` if your change affects the build.
 4. Open a PR against `master`.
 
-Keep PRs small and focused. If adding a new LLVM version, always test at least one platform locally before opening the PR.
+Keep PRs small and focused.
 
 ## Need Help?
 

--- a/README.md
+++ b/README.md
@@ -76,13 +76,38 @@ Or download pre-built binaries directly from the [Releases](https://github.com/c
 
 > [!NOTE]
 >
-> Removed support for v7 (released in May 2019) by February 2025.
+> ### Version Support Policy
 >
-> Removed support for v8 (released in July 2019) by September 2025.
+> Each release includes a **rolling window of the latest LLVM major versions**.
+> Older versions are retired on a regular cadence to keep build times manageable
+> and maintenance sustainable.
 >
-> Removed support for v9 (released in September 2019) in March 2026.
+> **Current policy:** The `N` latest major LLVM versions are supported, where `N`
+> is determined by the project maintainers (typically 7–8 major versions). When a
+> new LLVM version is added, the oldest one is retired in the same release.
 >
-> Removed support for v10 (released in March 2020) in March 2026.
+> **Retired versions:**
+>
+> | Version | Released   | Retired   |
+> |---------|------------|-----------|
+> | v7      | May 2019   | Feb 2025  |
+> | v8      | Jul 2019   | Sep 2025  |
+> | v9      | Sep 2019   | Mar 2026  |
+> | v10     | Mar 2020   | Mar 2026  |
+> | v11     | Oct 2020   | TBD       |
+>
+> Binaries for retired versions remain available in historical releases on the
+> [Releases page](https://github.com/cpp-linter/clang-tools-static-binaries/releases).
+> Each release ships an immutable [`versions.json`](#download) that documents
+> exactly which LLVM versions are included — downstream tools (pip, asdf, Homebrew)
+> should use this file to discover available versions rather than hardcoding a list.
+>
+> If you need a retired version, you can still download it from an older release,
+> or build it locally using `python build.py --version <N>`.
+>
+> Retiring a version is a **build-time and storage decision**, not a statement
+> about the quality of that LLVM release. Old binaries remain on GitHub Releases
+> indefinitely.
 
 ## Download
 


### PR DESCRIPTION
## Summary

Formalizes the version support policy that the project has been implicitly following (retiring old LLVM versions as new ones are added).

## Changes

### `README.md`
- Replaced the ad-hoc "Removed support for v7/v8/v9/v10" notes with a structured **Version Support Policy** section
- Added a retired versions table with release/retirement dates
- Explained the rolling window policy (latest 7–8 major versions)
- Advised downstream tools (pip, asdf, Homebrew) to use `versions.json` instead of hardcoding version lists

### `CONTRIBUTING.md`
- Added **Version retirement policy** — when adding version `N`, remove version `N-8` (or older) from `releases.json`
- Added **New tools and older LLVM versions** — explains that tools like `clang-include-cleaner` cannot be backported to older LLVM; the ❌ in the support matrix is the intended way to communicate this

## Motivation

The repo currently builds **12 LLVM versions (11–22) × 6 platforms = 72 build jobs per release**, producing ~637 artifacts. As the project grows, this cadence is becoming harder to sustain. A clear, documented retirement policy lets us reduce the version window to a sustainable 6–8 versions without surprising users.

See #115 for the full discussion.