### PR TITLE
chore: consolidate per-binary .sha512sum files into single SHA512SUMS file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,8 +80,9 @@ jobs:
       with:
         name: clang-tools-${{ matrix.release }}-${{ env.suffix }}
         path: |
-          ${{ matrix.release }}/build/**/clang-*-${{ env.suffix }}*
-          ${{ matrix.release }}/build/**/llvm-*-${{ env.suffix }}*
+          ${{ matrix.release }}/build/**/clang-*-${{ env.suffix }}
+          ${{ matrix.release }}/build/**/llvm-*-${{ env.suffix }}
+          ${{ matrix.release }}/build/**/SHA512SUMS
         # ** covers both bin/ (Linux/macOS) and MinSizeRel/bin/ (Windows)
         # clang-* matches clang-format, clang-tidy, clang-query, clang-scan-deps, etc.
         # llvm-* matches llvm-cov, llvm-profdata, llvm-symbolizer

--- a/README.md
+++ b/README.md
@@ -118,7 +118,16 @@ Or download pre-built binaries directly from the [Releases](https://github.com/c
 ## How can I trust this repository?
 
 - Releases are **immutable** — once published, assets and metadata (`versions.json`) are never modified.
-- Verify sha512sums of binaries against output from GitHub Actions to make sure binaries are not modified
+- Verify checksums using the SHA512SUMS file included in every release:
+
+  ```bash
+  # Download a binary and its SHA512SUMS file for your platform/version
+  # Then verify:
+  sha512sum -c SHA512SUMS --ignore-missing
+  ```
+
+  Each SHA512SUMS file contains SHA-512 hashes for all binaries in that
+  platform+version group, in the standard POSIX format used by Linux distributions.
 - Fork this repository and run GitHub actions on your behalf
 - Build and test manually using `python build.py` (see above) or the steps in [.github/workflows](https://github.com/cpp-linter/clang-tools-static-binaries/tree/master/.github/workflows)
 
@@ -168,4 +177,4 @@ Run `python build.py --help` for the full list of options.
 The script performs exactly the same steps as the CI workflow:
 downloads the LLVM source, applies any necessary patches, configures and
 builds with CMake, smoke-tests each binary, and writes the renamed
-binaries and their sha512sum files into `<release>/build/bin/`.
+binaries and a `SHA512SUMS` checksum file into `<release>/build/bin/`.

--- a/build.py
+++ b/build.py
@@ -440,14 +440,16 @@ def build(version: str, target_platform: str, script_dir: Path) -> None:
         src.rename(dst)
 
     # ------------------------------------------------------------------
-    # 8. Generate sha512sums
+    # 8. Generate SHA512SUMS (single file with all checksums)
     # ------------------------------------------------------------------
-    for tool in tools:
-        binary = bins / f"{tool}-{suffix}{dot_exe}"
-        digest = sha512_file(binary)
-        sha_file = bins / f"{tool}-{suffix}{dot_exe}.sha512sum"
-        sha_file.write_text(f"{digest}  {binary.name}\n")
-        print(f"{digest}  {binary.name}")
+    sha512sums_path = bins / "SHA512SUMS"
+    with open(sha512sums_path, "w") as sha_file:
+        for tool in tools:
+            binary = bins / f"{tool}-{suffix}{dot_exe}"
+            digest = sha512_file(binary)
+            sha_file.write(f"{digest}  {binary.name}\n")
+            print(f"{digest}  {binary.name}")
+    print(f"Checksums written to {sha512sums_path.name}")
 
     print(f"\nBuild complete. Artifacts are in: {bins.resolve()}")
 


### PR DESCRIPTION
GitHub releases have a 1000-asset limit. With 11 LLVM versions × 6 platforms
× 9 tools, the per-binary .sha512sum files pushed the total over the limit.

Replace 558 individual .sha512sum files with one SHA512SUMS file per
build (66 files total), reducing release assets from ~1117 to ~625.

Changes:
- build.py: generate a single SHA512SUMS file instead of per-binary .sha512sum
- build.yml: update artifact upload patterns for SHA512SUMS
- README.md: update verification instructions and description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release builds now include a single `SHA512SUMS` file with checksums for all packaged binaries.
  * Artifact uploads now explicitly include the checksum file alongside release binaries.

* **Documentation**
  * Updated build and verification instructions to reflect the new checksum file format.
  * Added clearer guidance on verifying release downloads with `sha512sum -c SHA512SUMS --ignore-missing`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->