### PR TITLE
fix: consolidate per-platform SHA512SUMS into single file to avoid upload collisions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,8 +203,18 @@ jobs:
             done
           }
 
+          # Combine all per-artifact SHA512SUMS into a single file at the workspace root.
+          # This mirrors the common open-source convention (e.g. Node.js SHASUMS256.txt)
+          # and avoids GitHub Release asset name collisions.
+          combined_sha="SHA512SUMS"
+          find clang-tools-* -name SHA512SUMS -type f -print0 | xargs -0 cat > "$combined_sha"
+          echo "Created combined $(wc -l < "$combined_sha")-entry $combined_sha"
+
+          # Remove the per-artifact SHA512SUMS files so they are not uploaded individually.
+          find clang-tools-* -name SHA512SUMS -type f -delete
+
           # Collect all files and upload one-by-one with a small delay
-          mapfile -t files < <(find clang-* -type f)
+          mapfile -t files < <(find clang-tools-* -type f)
 
           if [[ ${#files[@]} -eq 0 ]]; then
             echo "::warning::No files found to upload"
@@ -213,8 +223,9 @@ jobs:
 
           echo "Found ${#files[@]} files to upload"
           failed=0
-          # Upload versions.json
+          # Upload top-level metadata files first (no filename conflicts)
           upload_with_retry "versions.json" || failed=1
+          upload_with_retry "SHA512SUMS" || failed=1
           for file in "${files[@]}"; do
             upload_with_retry "$file" || failed=1
             sleep 1


### PR DESCRIPTION
## Problem

When releasing, each build artifact (version × platform) contains a `SHA512SUMS` file with the same filename. GitHub Release assets are keyed by filename, so every `SHA512SUMS` after the first fails to upload:

```
asset under the same name already exists: [SHA512SUMS]
Error: Failed to upload SHA512SUMS after 5 attempts
```

This affected **10 out of 10** SHA512SUMS files per release (all platforms except the first one alphabetically).

## Solution

Combine all per-artifact `SHA512SUMS` files into a single file at the workspace root before uploading. This follows the common open-source convention (e.g. Node.js `SHASUMS256.txt`, Debian `SHA256SUMS`).

The combined `SHA512SUMS` contains checksums for **all platforms and LLVM versions** — users can verify any binary with a single `sha512sum -c SHA512SUMS --ignore-missing` command.

### Changes

``.github/workflows/build.yml`` — in the `draft-release` job:

1. **Merge**: collect all per-artifact `SHA512SUMS` and concatenate into one
2. **Cleanup**: delete the per-artifact copies so they aren't uploaded redundantly
3. **Upload**: upload the combined `SHA512SUMS` alongside `versions.json`

## Backward Compatibility

**No user-facing change.** The Release page still has a single `SHA512SUMS` file; the verification command (`sha512sum -c SHA512SUMS --ignore-missing`) works the same as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release asset handling to avoid duplicate or conflicting checksum files during uploads.
  * Standardized upload order so release metadata and checksums are published first, making releases more reliable.
  * Narrowed packaged artifacts to the intended tool directories, reducing unintended files from being included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->