### PR TITLE
fix: restore trailing wildcard in artifact upload glob for Windows .exe binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,8 +80,8 @@ jobs:
       with:
         name: clang-tools-${{ matrix.release }}-${{ env.suffix }}
         path: |
-          ${{ matrix.release }}/build/**/clang-*-${{ env.suffix }}
-          ${{ matrix.release }}/build/**/llvm-*-${{ env.suffix }}
+          ${{ matrix.release }}/build/**/clang-*-${{ env.suffix }}*
+          ${{ matrix.release }}/build/**/llvm-*-${{ env.suffix }}*
           ${{ matrix.release }}/build/**/SHA512SUMS
         # ** covers both bin/ (Linux/macOS) and MinSizeRel/bin/ (Windows)
         # clang-* matches clang-format, clang-tidy, clang-query, clang-scan-deps, etc.


### PR DESCRIPTION
## Summary

Fix a glob pattern bug in the `Upload artifacts` step of `build.yml` that caused all Windows binaries to be missing from the published release.

## Root Cause

Commit `ae20618` accidentally dropped the trailing `*` from the `clang-*` and `llvm-*` glob patterns when adding the `SHA512SUMS` upload path.

**Before (broken) vs After (fixed):**

| Pattern | Effect |
|---------|--------|
| `clang-*-${{ env.suffix }}*` | ✅ Linux/macOS matches bare files, Windows matches `.exe` files |
| `clang-*-${{ env.suffix }}` | ❌ Cannot match `.exe` suffix on Windows, causing all Windows binaries to be omitted |

Release `2026.06.29-ae206185` ended up with 374 assets total (186 Linux + 186 macOS), and **zero** Windows assets.

## Fix

Restore the trailing `*` to both glob patterns:

- `clang-*-${{ env.suffix }}` → `clang-*-${{ env.suffix }}*`
- `llvm-*-${{ env.suffix }}` → `llvm-*-${{ env.suffix }}*`

## Next Steps

After merging this PR, re-trigger a CI build to produce a new release that includes Windows binaries. Then update the `binary_tag` in `clang-tools-pip` to point to the new release.